### PR TITLE
Fix "ReferenceError: isDefined is not defined" error

### DIFF
--- a/angular-mocks.js
+++ b/angular-mocks.js
@@ -316,7 +316,7 @@ angular.mock.$LogProvider = function() {
   }
 
   this.debugEnabled = function(flag) {
-	  if (isDefined(flag)) {
+	  if (angular.isDefined(flag)) {
 		  debug = flag;
 		  return this;
 	  } else {


### PR DESCRIPTION
It appears that the $LogProvider code was copied directly from the angular.js implementation, where 'isDefined' refers to the 'angular.isDefined' method. This fixes the angular-mocks file so that $LogProvider.debugEnabled uses angular.isDefined instead of isDefined.

(This PR can't be automatically merged, because there is no branch corresponding to the v1.2.0-rc.1 tag.)
