### PR TITLE
this is how the 1.2.4 release should have looked like

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "angular-mocks",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "./angular-mocks.js",
   "dependencies": {
-    "angular": "1.2.3"
+    "angular": "1.2.4"
   }
 }


### PR DESCRIPTION
Sorry for the stupid PR, but if you turn off issues that's the only way.

I've reported this before, if you specify a specific angular version you have to bump it with every release.
