### PR TITLE
Update angular-mocks.js

### DIFF
--- a/angular-mocks.js
+++ b/angular-mocks.js
@@ -1203,22 +1203,24 @@ function createHttpBackendMock($rootScope, $delegate, $browser) {
       wasExpected = true;
     }
 
-    var i = -1, definition;
-    while ((definition = definitions[++i])) {
-      if (definition.match(method, url, data, headers || {})) {
-        if (definition.response) {
-          // if $browser specified, we do auto flush all requests
-          ($browser ? $browser.defer : responsesPush)(wrapResponse(definition));
-        } else if (definition.passThrough) {
-          $delegate(method, url, data, callback, headers, timeout, withCredentials);
-        } else throw new Error('No response defined !');
-        return;
+    if (definitions.length > 0) {
+      var i = -1, definition;
+      while ((definition = definitions[++i])) {
+        if (definition.match(method, url, data, headers || {})) {
+          if (definition.response) {
+            // if $browser specified, we do auto flush all requests
+            ($browser ? $browser.defer : responsesPush)(wrapResponse(definition));
+          } else if (definition.passThrough) {
+            $delegate(method, url, data, callback, headers, timeout, withCredentials);
+          } else throw new Error('No response defined !');
+          return;
+        }
       }
+      throw wasExpected ?
+          new Error('No response defined !') :
+          new Error('Unexpected request: ' + method + ' ' + url + '\n' +
+                    (expectation ? 'Expected ' + expectation : 'No more request expected'));
     }
-    throw wasExpected ?
-        new Error('No response defined !') :
-        new Error('Unexpected request: ' + method + ' ' + url + '\n' +
-                  (expectation ? 'Expected ' + expectation : 'No more request expected'));
   }
 
   /**


### PR DESCRIPTION
Avoid "No more request expected" errors on legal tests wih no definitions, by checking definitions.length to be > 0 before throwing new Error
