### PR TITLE
Just checking if cleanData is available to call.

### DIFF
--- a/angular-mocks.js
+++ b/angular-mocks.js
@@ -2909,7 +2909,9 @@ angular.mock.$RootScopeDecorator = ['$delegate', function($delegate) {
       if (rootNode && (!originalRootElement || rootNode !== originalRootElement[0])) {
         cleanUpNodes.push(rootNode);
       }
-      angular.element.cleanData(cleanUpNodes);
+
+      // Ensure `cleanData()` is available, before calling it      
+      if (angular.element && angular.element.cleanData) angular.element.cleanData(cleanUpNodes);
 
       // Ensure `$destroy()` is available, before calling it
       // (a mocked `$rootScope` might not implement it (or not even be an object at all))


### PR DESCRIPTION
Hi, 
I was testing a small project then realised my unit test are failing showing me the following message 

PhantomJS 1.9.8 (Mac OS X 0.0.0) Controller: MainCtrl should attach a list of awesomeThings to the scope FAILED
    TypeError: 'undefined' is not a function (evaluating 'angular.element.cleanData(cleanUpNodes)')
        at /Users/afshintm/Repos/ntodo/bower_components/angular-mocks/angular-mocks.js:2812
        at /Users/afshintm/Repos/ntodo/bower_components/angular-mocks/angular-mocks.js:2772

Then I found cleanData is undefined, so I just checked it availability before calling that.

Cheers,
